### PR TITLE
Update README.adoc

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -63,13 +63,14 @@ B - Deleting a file
 
 ```
 
-C - Adjusting Timeout and Socket Timeout
+C - Adjusting Timeout, Socket Timeout  and encryption on transit
 
 ```java
 
     SmbConfig config = SmbConfig.builder()
             .withTimeout(120, TimeUnit.SECONDS) // Timeout sets Read, Write, and Transact timeouts (default is 60 seconds)
             .withSoTimeout(180, TimeUnit.SECONDS) // Socket Timeout (default is 0 seconds, blocks forever)
+			.withEncryptData(true) // This will allow to connect to folders with encryption on transit enabled
             .build();
 
     SMBClient client = new SMBClient(config);


### PR DESCRIPTION
Adding encrypt data on the example configurations, as this is a common feature used in enterprise environments. I think it could save time to developers who search this option, and it will provide it at first sight.